### PR TITLE
⚙️ PR 생성 시 커버리지 체크 & 코멘트로 커버리지 리포팅하도록 설정

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# 코드 커버리지 상태에 대한 설정을 정의
+coverage:
+  status:
+    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+      default:
+        # basic
+        target: auto #default
+        threshold: 0%
+        base: auto
+
+# PR(풀 리퀘스트)에 대한 Codecov의 댓글 설정을 정의
+comment: #this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false # if true: only post the comment if coverage changes
+  require_base: false # [true :: must have a base report to post]
+  require_head: true # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]


### PR DESCRIPTION
## PR 생성 시 커버리지 체크 & 코멘트로 커버리지 리포팅하도록 설정하기
- [가이드](https://docs.codecov.com/docs/quick-start#tips-and-tricks) 참조
- 참고로 이 yml 파일은 github workflow와 별도의 yml로서 루트 위치에 놓여있어야 함. 다음 [링크](https://docs.codecov.com/docs/codecov-yaml#repository-yaml)도 참조
- 다음으로 [codecov GHA를 저장소에 설치](https://github.com/marketplace/codecov)하기
public 저장소에게 제공되는 무료 옵션 선택
- 코멘트가 생성되는건 약간 시간이 걸림. 체크가 다 끝나고 난 뒤에 코멘트가 달리기도 함.