### PR TITLE
CircleCI에서 Cypress 테스트 실행

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/base
+      - image: cimg/base:current
+
+    # Add steps to the job
+    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      # Checkout the code as the first step.
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,20 @@ orbs:
   # version "s.x.y" of the orb. We recommend you then use
   # the strict explicit version "cypress-io/cypress@3.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@3.3.1
+
+jobs:
+  cypress-run:
+    executor:
+      name: cypress/default
+      node-version: "20.6.0"
+    steps:
+      - cypress/install
+      - cypress/run-tests:
+          cypress-command: "npx wait-on@latest http://localhost:3000 && npx cypress run"
+          start-command: "npm run build && npm run start"
+
 workflows:
   build:
     jobs:
-      - cypress/run: # "run" job comes from "cypress" orb
-          start-command: "npm run start"
+      - cypress-run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,12 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
-jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
-    docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/base
-      - image: cimg/base:current
-
-    # Add steps to the job
-    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
-    steps:
-      # Checkout the code as the first step.
-      - checkout
-      - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
-
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
+orbs:
+  # "cypress-io/cypress@3" installs the latest published
+  # version "s.x.y" of the orb. We recommend you then use
+  # the strict explicit version "cypress-io/cypress@3.x.y"
+  # to lock the version and prevent unexpected CI changes
+  cypress: cypress-io/cypress@3
 workflows:
-  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  build:
     jobs:
-      - say-hello
+      - cypress/run # "run" job comes from "cypress" orb
+          start-command: 'npm run start'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,5 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run # "run" job comes from "cypress" orb
-          start-command: 'npm run start'
+      - cypress/run: # "run" job comes from "cypress" orb
+          start-command: "npm run start"

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,5 +1,15 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})
+describe("template spec", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000");
+  });
+
+  it('should contain "Get started by ~" text', () => {
+    cy.contains("Get started by editing");
+  });
+
+  it('should contain "Lean" heading anchor with correct href prop', () => {
+    cy.contains("Learn")
+      .should("have.attr", "href")
+      .and("include", "https://nextjs.org/learn");
+  });
+});


### PR DESCRIPTION
- cypress 테스트
  - 기본 경로(’/’) 에 “Get started by” 라는 텍스트가 존재하는 것 검증
  - 기본 경로(”/”)에 “Learn”라는 anchor heading이 있고 이 anchor의 href 속성이 정확하게 설정돼 있는지 검증


- CircleCI에서 Cypress 테스트가 정상적으로 실행되도록 설정하기
  - executor의 노드 버전을 18.17.0 이상으로 설정하기
  - 로컬 서버 실행 명령어를 개발 빌드(npm run dev)가 아닌 프로덕션 빌드로 실행하기(npm run build && npm run start)
  - Cypress가 로컬 서버가 실행될때까지 기다리도록 wait-on 명령어 사용하기
  - Cypress orb의 [run-tests 명령어](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-run-tests)와 [default executor 부분](https://circleci.com/developer/orbs/orb/cypress-io/cypress#executors-default) 참조